### PR TITLE
Update getting-started.md

### DIFF
--- a/src/docs/panel/getting-started.md
+++ b/src/docs/panel/getting-started.md
@@ -215,7 +215,7 @@ Then, rebuild the Dockerfiles and fully restart the containers.
 
 ```bash
 docker compose down
-docker compose up -d --build --no-cache
+docker compose up -d --build
 ```
 
 ### Adding a User
@@ -244,7 +244,7 @@ and reset the cache.
 
 ```bash
 docker compose down
-docker compose up -d --build --no-cache
+docker compose up -d --build
 docker compose exec workspace bash -c "php artisan optimize:clear && \
                                        php artisan optimize"
 ```


### PR DESCRIPTION
--no-cache in docker compose syntax does not function with default install.